### PR TITLE
seo fix - sycgeeks

### DIFF
--- a/packages/seo/src/utils/buildTags.ts
+++ b/packages/seo/src/utils/buildTags.ts
@@ -5,14 +5,14 @@ const createMetaTag = (attributes: Record<string, string>): string => {
   const attrs = Object.entries(attributes)
     .map(([key, value]) => `${key}="${escape(value)}"`)
     .join(" ");
-  return `<meta ${attrs} />`;
+  return `<meta ${attrs}>`;
 };
 
 const createLinkTag = (attributes: Record<string, string>): string => {
   const attrs = Object.entries(attributes)
     .map(([key, value]) => `${key}="${escape(value)}"`)
     .join(" ");
-  return `<link ${attrs} />`;
+  return `<link ${attrs}>`;
 };
 
 const createOpenGraphTag = (property: string, content: string): string => {
@@ -63,7 +63,7 @@ export const buildTags = (config: AstroSeoProps): string => {
     addTag(
       `<meta ${Object.entries(attributes)
         .map(([key, value]) => `${key}="${escape(value)}"`)
-        .join(" ")} />`
+        .join(" ")}>`
     );
   };
 
@@ -71,7 +71,7 @@ export const buildTags = (config: AstroSeoProps): string => {
     addTag(
       `<link ${Object.entries(attributes)
         .map(([key, value]) => `${key}="${escape(value)}"`)
-        .join(" ")} />`
+        .join(" ")}>`
     );
   };
 


### PR DESCRIPTION
removed trailing slash on meta tags. w3validator warning: trailing slash on void elements has no effect and interacts badly with unquoted attribute values.