### PR TITLE
fix: missing max-video-preview

### DIFF
--- a/packages/seo/src/utils/buildTags.ts
+++ b/packages/seo/src/utils/buildTags.ts
@@ -116,6 +116,7 @@ export const buildTags = (config: AstroSeoProps): string => {
       unavailableAfter,
       noimageindex,
       notranslate,
+      maxVideoPreview
     } = config.robotsProps;
 
     if (nosnippet) robotsContent.push("nosnippet");
@@ -127,6 +128,7 @@ export const buildTags = (config: AstroSeoProps): string => {
       robotsContent.push(`unavailable_after:${unavailableAfter}`);
     if (noimageindex) robotsContent.push("noimageindex");
     if (notranslate) robotsContent.push("notranslate");
+    if (typeof maxVideoPreview === 'number') robotsContent.push(`max-video-preview:${maxVideoPreview}`);
   }
 
   if (robotsContent.length > 0) {


### PR DESCRIPTION
The type declaration specifies [maxVideoPreview](https://github.com/onwidget/astrolib/blob/aeae2e6fb7e6323f032aacbf99df55149a4e796c/packages/seo/src/types.ts#L433), but it is not added to the meta tags. This pull request aims to fix that.